### PR TITLE
Make timers thread_local

### DIFF
--- a/src/xpu/detail/timers.cpp
+++ b/src/xpu/detail/timers.cpp
@@ -16,7 +16,7 @@ struct timer {
     timer() : start(std::chrono::high_resolution_clock::now()) {}
 };
 
-static struct {
+thread_local static struct {
     std::vector<timer> stack;
 } T;
 


### PR DESCRIPTION
Required to bypass the lack of threadsafetyness of timers