### PR TITLE
Fix template type in image lookup for CPU

### DIFF
--- a/src/xpu/detail/runtime.h
+++ b/src/xpu/detail/runtime.h
@@ -157,7 +157,7 @@ private:
         }
         m_images.add(i, d);
 
-        if (d != cpu && m_images.find<I>(cpu) == nullptr) {
+        if (d != cpu && m_images.find< image<I> >(cpu) == nullptr) {
             XPU_LOG("Loading image '%s' for CPU.", type_name<I>());
             image<I> *cpu_image = new image<I>{};
             cpu_image->dump_symbols();


### PR DESCRIPTION
There is a small type mismatch in `load_image<I>()`.

The CPU image is added to `image_pool` as `image<I>`, but the existence check is performed using `I`:

```cpp
m_images.find<I>(cpu)
```

Because of this, the runtime may fail to detect an already loaded CPU image and try to add it again. In that case,

```cpp
m_images.add(cpu_image, cpu)
```

will fail with an `"image already exists"` error.

Suggested fix:

```cpp
m_images.find<image<I>>(cpu)
```

This makes the lookup use the same type under which the image is actually stored in `image_pool`. It prevents duplicate CPU image loading when the same device image is loaded for another backend or when the CPU image has already been preloaded.
